### PR TITLE
Add HG002 data download script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ This project aims to reproduce and evaluate variant calling pipelines (e.g., Dee
 
 ## Data Sources:
 - GIAB: [ftp://ftp-trace.ncbi.nlm.nih.gov/giab/](ftp://ftp-trace.ncbi.nlm.nih.gov/giab/)
+
+### Downloading HG002 data
+
+Use the `download_hg002_giab.py` script to fetch the benchmark VCF and BED files:
+
+```bash
+python scripts/download_hg002_giab.py --outdir data
+```
+
+This will create a `data` directory containing the HG002 benchmark files required for evaluation.

--- a/scripts/download_hg002_giab.py
+++ b/scripts/download_hg002_giab.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Download HG002 GIAB benchmark data files.
+
+This script downloads the HG002 benchmark VCF and BED files from the
+Genome in a Bottle (GIAB) FTP site. The default output directory is
+``data`` but can be overridden with ``-o`` or ``--outdir``.
+
+Usage::
+
+    python download_hg002_giab.py [--outdir DATA_DIR]
+
+"""
+import argparse
+import os
+from urllib.request import urlretrieve
+from urllib.parse import urljoin
+
+BASE_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/giab/ftp/release/"
+    "AshkenazimTrio/HG002_NA24385_son/latest/GRCh38/"
+)
+FILES = [
+    "HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz",
+    "HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi",
+    "HG002_GRCh38_1_22_v4.2.1_benchmark.bed",
+]
+
+def download_file(filename: str, outdir: str) -> None:
+    """Download a single file from GIAB if it does not already exist."""
+    os.makedirs(outdir, exist_ok=True)
+    dest = os.path.join(outdir, filename)
+    if os.path.exists(dest):
+        print(f"[skip] {filename} already exists")
+        return
+    url = urljoin(BASE_URL, filename)
+    print(f"[download] {url} -> {dest}")
+    urlretrieve(url, dest)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download HG002 GIAB data")
+    parser.add_argument(
+        "-o",
+        "--outdir",
+        default="data",
+        help="Output directory for downloaded files",
+    )
+    args = parser.parse_args()
+
+    for fname in FILES:
+        download_file(fname, args.outdir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a script to download HG002 GIAB benchmark data
- document how to fetch the dataset in the README

## Testing
- `python -m py_compile scripts/download_hg002_giab.py`
- `python scripts/download_hg002_giab.py --help`
- `python scripts/download_hg002_giab.py --outdir data` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684ada514e1c8333b100771683634086