### PR TITLE
Add visualization script for evaluation results

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project aims to reproduce and evaluate variant calling pipelines (e.g., Dee
 2. Set up Python conda environment
 3. Install variant calling tools (DeepVariant, GATK)
 4. Run evaluation pipeline
+5. Visualize evaluation results
 
 ## Environment:
 - Python 3.10
@@ -17,3 +18,58 @@ This project aims to reproduce and evaluate variant calling pipelines (e.g., Dee
 
 ## Data Sources:
 - GIAB: [ftp://ftp-trace.ncbi.nlm.nih.gov/giab/](ftp://ftp-trace.ncbi.nlm.nih.gov/giab/)
+
+### Downloading HG002 data
+
+Use the `download_hg002_giab.py` script to fetch the benchmark VCF and BED files:
+
+```bash
+python scripts/download_hg002_giab.py --outdir data
+```
+
+This will create a `data` directory containing the HG002 benchmark files required for evaluation.
+
+### Setting up the conda environment
+
+Create the Python environment and install the required tools using `environment.yml`:
+
+```bash
+conda env create -f environment.yml
+conda activate seqc2
+```
+
+The environment installs **DeepVariant**, **GATK**, and **hap.py** from Bioconda.
+
+Alternatively, run the helper script:
+
+```bash
+./scripts/setup_conda_env.sh
+```
+
+### Running the evaluation pipeline
+
+After downloading the HG002 truth data and creating the environment,
+run the pipeline to generate variant calls with DeepVariant and compare
+them to the GIAB benchmark set using `hap.py`:
+
+```bash
+python scripts/run_evaluation_pipeline.py \
+  --bam path/to/aligned.bam \
+  --ref path/to/reference.fasta \
+  --outdir results
+```
+
+This will produce a `results` directory containing the DeepVariant VCF and
+evaluation metrics from `hap.py`.
+
+### Visualizing the evaluation
+
+The hap.py output includes a `happy.summary.csv` file with precision,
+recall and F1-score metrics. Use the `visualize_evaluations.py` script
+to generate a simple bar plot:
+
+```bash
+python scripts/visualize_evaluations.py results/happy -o metrics.png
+```
+
+Open `metrics.png` to view the plotted scores.

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,15 @@
+name: seqc2
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - python=3.10
+  - pip
+  - gatk4
+  - deepvariant
+  - hap.py
+  - samtools
+  - bcftools
+  - pandas
+  - matplotlib

--- a/scripts/download_hg002_giab.py
+++ b/scripts/download_hg002_giab.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Download HG002 GIAB benchmark data files.
+
+This script downloads the HG002 benchmark VCF and BED files from the
+Genome in a Bottle (GIAB) FTP site. The default output directory is
+``data`` but can be overridden with ``-o`` or ``--outdir``.
+
+Usage::
+
+    python download_hg002_giab.py [--outdir DATA_DIR]
+
+"""
+import argparse
+import os
+from urllib.request import urlretrieve
+from urllib.parse import urljoin
+
+BASE_URL = (
+    "https://ftp.ncbi.nlm.nih.gov/giab/ftp/release/"
+    "AshkenazimTrio/HG002_NA24385_son/latest/GRCh38/"
+)
+FILES = [
+    "HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz",
+    "HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz.tbi",
+    "HG002_GRCh38_1_22_v4.2.1_benchmark.bed",
+]
+
+def download_file(filename: str, outdir: str) -> None:
+    """Download a single file from GIAB if it does not already exist."""
+    os.makedirs(outdir, exist_ok=True)
+    dest = os.path.join(outdir, filename)
+    if os.path.exists(dest):
+        print(f"[skip] {filename} already exists")
+        return
+    url = urljoin(BASE_URL, filename)
+    print(f"[download] {url} -> {dest}")
+    urlretrieve(url, dest)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download HG002 GIAB data")
+    parser.add_argument(
+        "-o",
+        "--outdir",
+        default="data",
+        help="Output directory for downloaded files",
+    )
+    args = parser.parse_args()
+
+    for fname in FILES:
+        download_file(fname, args.outdir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_evaluation_pipeline.py
+++ b/scripts/run_evaluation_pipeline.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Run variant calling and evaluate results against HG002 benchmarks.
+
+This script executes DeepVariant to call variants from an aligned BAM/CRAM file
+and then compares the calls against the Genome in a Bottle HG002 truth set using
+``hap.py``.
+
+Example::
+
+    python scripts/run_evaluation_pipeline.py \
+        --bam sample.bam \
+        --ref GRCh38.fa \
+        --outdir results
+"""
+import argparse
+import os
+import subprocess
+from typing import List
+
+def run(cmd: List[str]) -> None:
+    """Run a command and stream output."""
+    print("[run]", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+def run_deepvariant(bam: str, ref: str, out_dir: str) -> str:
+    """Run DeepVariant and return the path to the output VCF."""
+    vcf_path = os.path.join(out_dir, "deepvariant.vcf.gz")
+    cmd = [
+        "run_deepvariant",
+        f"--model_type=WGS",
+        f"--ref={ref}",
+        f"--reads={bam}",
+        f"--output_vcf={vcf_path}",
+        f"--num_shards={os.cpu_count() or 1}",
+    ]
+    run(cmd)
+    return vcf_path
+
+def run_happy(truth_vcf: str, truth_bed: str, query_vcf: str, ref: str, out_dir: str) -> None:
+    """Compare query VCF against truth using hap.py."""
+    cmd = [
+        "hap.py",
+        truth_vcf,
+        query_vcf,
+        "-f",
+        truth_bed,
+        "-r",
+        ref,
+        "-o",
+        os.path.join(out_dir, "happy"),
+    ]
+    run(cmd)
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run variant calling and evaluation")
+    parser.add_argument("--bam", required=True, help="Input aligned BAM/CRAM file")
+    parser.add_argument("--ref", required=True, help="Reference FASTA")
+    parser.add_argument("--truth-vcf", default="data/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz", help="Benchmark VCF")
+    parser.add_argument("--truth-bed", default="data/HG002_GRCh38_1_22_v4.2.1_benchmark.bed", help="Benchmark BED")
+    parser.add_argument("-o", "--outdir", default="results", help="Output directory")
+    args = parser.parse_args()
+
+    os.makedirs(args.outdir, exist_ok=True)
+    query_vcf = run_deepvariant(args.bam, args.ref, args.outdir)
+    run_happy(args.truth_vcf, args.truth_bed, query_vcf, args.ref, args.outdir)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_conda_env.sh
+++ b/scripts/setup_conda_env.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Create and activate the seqc2 conda environment
+set -euo pipefail
+ENV_FILE="$(dirname "$0")/../environment.yml"
+
+echo "Creating conda environment from $ENV_FILE" >&2
+conda env create -f "$ENV_FILE" -n seqc2 || true
+
+echo "Activate the environment with:\n  conda activate seqc2" >&2

--- a/scripts/visualize_evaluations.py
+++ b/scripts/visualize_evaluations.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Visualize hap.py evaluation metrics."""
+
+import argparse
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Plot hap.py evaluation metrics")
+    parser.add_argument(
+        "prefix",
+        help="Prefix of hap.py output files (e.g. results/happy)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="evaluation_metrics.png",
+        help="Output image file",
+    )
+    args = parser.parse_args()
+
+    import pandas as pd
+    import matplotlib.pyplot as plt
+
+    summary_file = f"{args.prefix}.summary.csv"
+    df = pd.read_csv(summary_file)
+
+    metrics = df[df["Type"].isin(["SNP", "INDEL"])]
+    plot_df = metrics[["Type", "Recall", "Precision", "F1_Score"]].set_index("Type")
+    plot_df.plot(kind="bar")
+    plt.ylabel("Score")
+    plt.title("hap.py Evaluation Metrics")
+    plt.ylim(0, 1)
+    plt.tight_layout()
+    plt.savefig(args.output)
+    print(f"Plot saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `visualize_evaluations.py` helper for plotting hap.py metrics
- include pandas and matplotlib in the conda environment
- document the new visualization step in the README

## Testing
- `python -m py_compile scripts/download_hg002_giab.py`
- `python scripts/download_hg002_giab.py --help`
- `python scripts/download_hg002_giab.py --outdir data` *(fails: Tunnel connection failed 403 Forbidden)*
- `python -m py_compile scripts/run_evaluation_pipeline.py`
- `python scripts/run_evaluation_pipeline.py --help`
- `python -m py_compile scripts/visualize_evaluations.py`
- `python scripts/visualize_evaluations.py --help`
- `bash scripts/setup_conda_env.sh` *(fails: conda: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ada514e1c8333b100771683634086