### PR TITLE
Add tool availability checks and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,18 @@
 
 # SEQC2 GIAB Variant Calling Evaluation
 
-This project aims to reproduce and evaluate variant calling pipelines (e.g., DeepVariant, GATK) using the SEQC2-recommended reference sample HG002 from the Genome in a Bottle (GIAB) consortium.
+This project aims to reproduce and evaluate variant calling pipelines using the SEQC2-recommended reference sample HG002 from the Genome in a Bottle (GIAB) consortium.
 
 ## Steps:
 1. Download HG002 GIAB data
 2. Set up Python conda environment
-3. Install variant calling tools (DeepVariant, GATK)
+3. Install variant calling tools (DeepVariant)
 4. Run evaluation pipeline
 
 ## Environment:
 - Python 3.10
 - Conda environment: `seqc2`
-- Tools: DeepVariant / GATK
+- Tools: DeepVariant
 
 ## Data Sources:
 - GIAB: [ftp://ftp-trace.ncbi.nlm.nih.gov/giab/](ftp://ftp-trace.ncbi.nlm.nih.gov/giab/)
@@ -48,7 +48,7 @@ conda env create -f environment.yml
 conda activate seqc2
 ```
 
-The environment installs both **DeepVariant** and **GATK** from Bioconda.
+The environment installs **DeepVariant** from Bioconda.
 
 ### Running the evaluation pipeline
 

--- a/scripts/run_evaluation_pipeline.py
+++ b/scripts/run_evaluation_pipeline.py
@@ -15,6 +15,7 @@ Example::
 import argparse
 import os
 import subprocess
+import shutil
 from typing import List
 
 def run(cmd: List[str]) -> None:
@@ -24,6 +25,11 @@ def run(cmd: List[str]) -> None:
 
 def run_deepvariant(bam: str, ref: str, out_dir: str) -> str:
     """Run DeepVariant and return the path to the output VCF."""
+    if shutil.which("run_deepvariant") is None:
+        raise FileNotFoundError(
+            "DeepVariant executable 'run_deepvariant' not found in PATH. "
+            "Please install DeepVariant or add it to PATH."
+        )
     vcf_path = os.path.join(out_dir, "deepvariant.vcf.gz")
     cmd = [
         "run_deepvariant",
@@ -38,6 +44,11 @@ def run_deepvariant(bam: str, ref: str, out_dir: str) -> str:
 
 def run_happy(truth_vcf: str, truth_bed: str, query_vcf: str, ref: str, out_dir: str) -> None:
     """Compare query VCF against truth using hap.py."""
+    if shutil.which("hap.py") is None:
+        raise FileNotFoundError(
+            "Evaluation tool 'hap.py' not found in PATH. "
+            "Please install hap.py or add it to PATH."
+        )
     cmd = [
         "hap.py",
         truth_vcf,


### PR DESCRIPTION
## Summary
- verify run_deepvariant and hap.py presence before execution
- remove GATK references from README

## Testing
- `python -m py_compile scripts/run_evaluation_pipeline.py`
- `python scripts/run_evaluation_pipeline.py --bam dummy.bam --ref dummy.fa` (fails with expected 'run_deepvariant' not found error)


------
https://chatgpt.com/codex/tasks/task_e_6899e60dd31883338cee5d4188b0ecfb