### PR TITLE
docs: clean up README and add visualization guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,6 @@ python scripts/download_hg002_giab.py --outdir data
 
 This will create a `data` directory containing the HG002 benchmark files required for evaluation.
 
-
-### Downloading HG002 data
-
-Use the `download_hg002_giab.py` script to fetch the benchmark VCF and BED files:
-
-```bash
-python scripts/download_hg002_giab.py --outdir data
-```
-
-This will create a `data` directory containing the HG002 benchmark files required for evaluation.
-
 ### Setting up the conda environment
 
 Create the Python environment and install the required tools using `environment.yml`:
@@ -65,8 +54,15 @@ python scripts/run_evaluation_pipeline.py \
 
 This will produce a `results` directory containing the DeepVariant VCF and
 evaluation metrics from `hap.py`.
-environment.yml
+### Visualizing hap.py evaluation results
 
+After running the evaluation pipeline, you can plot the `hap.py` metrics using:
+
+```bash
+python scripts/visualize_evaluations.py results/happy -o evaluation_metrics.png
+```
+
+This creates an `evaluation_metrics.png` bar chart summarizing SNP and INDEL recall, precision, and F1 score.
 
 Alternatively, run the helper script:
 


### PR DESCRIPTION
## Summary
- remove duplicate HG002 data download instructions
- drop stray reference to `environment.yml`
- document how to visualize hap.py metrics with `scripts/visualize_evaluations.py`

## Testing
- `python -m py_compile scripts/*.py`
- `python scripts/visualize_evaluations.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6899e691c62c8333b6e5e6933c1f6124