### PR TITLE
Pin analysis package versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,8 @@ channels:
 dependencies:
   - python=3.10
   - pip
-  - gatk4
-  - deepvariant
+  - hap.py=0.3.14
+  - pandas=1.5
+  - matplotlib=3.7
+  - gatk4=4.3.0.0
+  - deepvariant=1.5.0


### PR DESCRIPTION
## Summary
- Pin hap.py, pandas, matplotlib, gatk4, and deepvariant versions for a reproducible conda environment

## Testing
- `bash scripts/setup_conda_env.sh` *(fails: conda: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899e695fc8c8333b44073dbeb146779