### PR TITLE
Add tests and pytest dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,4 @@ dependencies:
   - pip
   - gatk4
   - deepvariant
+  - pytest

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+import download_hg002_giab as dl
+
+
+def test_download_file_skips_existing(tmp_path, monkeypatch, capsys):
+    filename = "dummy.txt"
+    dest = tmp_path / filename
+    dest.write_text("existing")
+
+    def fake_urlretrieve(url, dest_path):
+        raise AssertionError("urlretrieve should not be called for existing files")
+
+    monkeypatch.setattr(dl, "urlretrieve", fake_urlretrieve)
+
+    dl.download_file(filename, str(tmp_path))
+    captured = capsys.readouterr().out
+    assert "[skip]" in captured

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1,0 +1,13 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
+import run_evaluation_pipeline as rep
+
+
+def test_run_raises_on_bad_command():
+    with pytest.raises(subprocess.CalledProcessError):
+        rep.run(["false"])


### PR DESCRIPTION
## Summary
- add tests ensuring `download_file` skips existing files
- ensure `run` raises errors for failing commands
- include pytest in environment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899e69d010c83338c1956e630c8b4a2