### PR TITLE
Add missing column checks in visualization script

### DIFF
--- a/scripts/visualize_evaluations.py
+++ b/scripts/visualize_evaluations.py
@@ -2,6 +2,8 @@
 """Visualize hap.py evaluation metrics."""
 
 import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
 
 
 def main() -> None:
@@ -18,11 +20,17 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    import pandas as pd
-    import matplotlib.pyplot as plt
-
     summary_file = f"{args.prefix}.summary.csv"
     df = pd.read_csv(summary_file)
+
+    required_columns = {"Type", "Recall", "Precision", "F1_Score"}
+    missing = required_columns.difference(df.columns)
+    if missing:
+        raise ValueError(
+            "Summary file {} is missing required column(s): {}".format(
+                summary_file, ", ".join(sorted(missing))
+            )
+        )
 
     metrics = df[df["Type"].isin(["SNP", "INDEL"])]
     plot_df = metrics[["Type", "Recall", "Precision", "F1_Score"]].set_index("Type")


### PR DESCRIPTION
## Summary
- Import pandas and matplotlib at the top of visualize_evaluations script
- Validate required columns exist in hap.py summary CSV with clear error message

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899e6b376b483338fdf735202a8ae4d