### PR TITLE
Add data analysis dependencies to environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,3 +8,6 @@ dependencies:
   - pip
   - gatk4
   - deepvariant
+  - 'hap.py'
+  - pandas
+  - matplotlib


### PR DESCRIPTION
## Summary
- add hap.py, pandas, and matplotlib to conda environment

## Testing
- `python -m py_compile scripts/download_hg002_giab.py scripts/run_evaluation_pipeline.py scripts/visualize_evaluations.py`
- Attempted to fetch micromamba for dependency resolution but received `CONNECT tunnel failed, response 403`


------
https://chatgpt.com/codex/tasks/task_e_6899e6ba91748333bdd22d72a4adb409