### PR TITLE
Check dependencies before running pipeline

### DIFF
--- a/scripts/run_evaluation_pipeline.py
+++ b/scripts/run_evaluation_pipeline.py
@@ -14,13 +14,34 @@ Example::
 """
 import argparse
 import os
+import shutil
 import subprocess
 from typing import List
+
+REQUIRED_TOOLS = ["run_deepvariant", "hap.py"]
+
+def check_required_tools() -> None:
+    """Ensure all external tools exist in PATH."""
+    missing = [tool for tool in REQUIRED_TOOLS if shutil.which(tool) is None]
+    if missing:
+        for tool in missing:
+            print(f"[run] Required command '{tool}' not found in PATH. Please install it and try again.")
+        raise SystemExit(1)
+
 
 def run(cmd: List[str]) -> None:
     """Run a command and stream output."""
     print("[run]", " ".join(cmd))
-    subprocess.run(cmd, check=True)
+    if shutil.which(cmd[0]) is None:
+        print(f"[run] Required command '{cmd[0]}' not found in PATH. Please install it and try again.")
+        raise SystemExit(1)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.stdout:
+        print(result.stdout)
+    if result.returncode != 0:
+        if result.stderr:
+            print(result.stderr)
+        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
 
 def run_deepvariant(bam: str, ref: str, out_dir: str) -> str:
     """Run DeepVariant and return the path to the output VCF."""
@@ -61,6 +82,7 @@ def main() -> None:
     args = parser.parse_args()
 
     os.makedirs(args.outdir, exist_ok=True)
+    check_required_tools()
     query_vcf = run_deepvariant(args.bam, args.ref, args.outdir)
     run_happy(args.truth_vcf, args.truth_bed, query_vcf, args.ref, args.outdir)
 


### PR DESCRIPTION
## Summary
- verify required CLI tools exist using `shutil.which`
- surface `subprocess` errors and stderr to the user

## Testing
- `python -m py_compile scripts/run_evaluation_pipeline.py`
- `python scripts/run_evaluation_pipeline.py --bam sample.bam --ref ref.fa` *(fails gracefully when tools missing)*
- `python - <<'PY'
from scripts.run_evaluation_pipeline import run
run(['bash','-lc','echo error_message >&2; exit 1'])
PY`


------
https://chatgpt.com/codex/tasks/task_e_6899e6c8731c8333b2b98147795b2463