### PR TITLE
Expose caller option before parsing and fix download helper

### DIFF
--- a/scripts/download_hg002_giab.py
+++ b/scripts/download_hg002_giab.py
@@ -13,8 +13,10 @@ Usage::
 import argparse
 import logging
 import os
+import hashlib
 from urllib.request import urlretrieve
 from urllib.parse import urljoin
+from typing import Union
 
 BASE_URL = (
     "https://ftp.ncbi.nlm.nih.gov/giab/ftp/release/"
@@ -49,24 +51,29 @@ def _compute_checksums(path: str) -> tuple[str, str]:
     return md5.hexdigest(), sha256.hexdigest()
 
 
-def download_file(file_info: dict, outdir: str) -> None:
+def download_file(file_info: Union[dict, str], outdir: str) -> None:
     """Download a single file from GIAB if it does not already exist."""
-    filename = file_info["name"]
-    expected_md5 = file_info["md5"]
-    expected_sha256 = file_info["sha256"]
+    if isinstance(file_info, dict):
+        filename = file_info["name"]
+        expected_md5 = file_info["md5"]
+        expected_sha256 = file_info["sha256"]
+    else:
+        filename = file_info
+        expected_md5 = expected_sha256 = None
     os.makedirs(outdir, exist_ok=True)
     dest = os.path.join(outdir, filename)
     if os.path.exists(dest):
-        logging.info("[skip] %s already exists", filename)
+        print(f"[skip] {filename} already exists")
         return
     url = urljoin(BASE_URL, filename)
     logging.info("[download] %s -> %s", url, dest)
     urlretrieve(url, dest)
-    md5_sum, sha256_sum = _compute_checksums(dest)
-    if md5_sum != expected_md5 or sha256_sum != expected_sha256:
-        print(f"[error] Checksum mismatch for {filename}; deleting file")
-        os.remove(dest)
-    else:
+    if expected_md5 and expected_sha256:
+        md5_sum, sha256_sum = _compute_checksums(dest)
+        if md5_sum != expected_md5 or sha256_sum != expected_sha256:
+            print(f"[error] Checksum mismatch for {filename}; deleting file")
+            os.remove(dest)
+            return
         print(f"[verified] {filename}")
 
 def main() -> None:

--- a/scripts/run_evaluation_pipeline.py
+++ b/scripts/run_evaluation_pipeline.py
@@ -44,7 +44,9 @@ def run(cmd: List[str]) -> None:
     if result.returncode != 0:
         if result.stderr:
             print(result.stderr)
-        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        )
 
 def run_deepvariant(bam: str, ref: str, out_dir: str) -> str:
     """Run DeepVariant and return the path to the output VCF."""
@@ -121,11 +123,17 @@ def main() -> None:
     parser.add_argument("--truth-bed", default="data/HG002_GRCh38_1_22_v4.2.1_benchmark.bed", help="Benchmark BED")
     parser.add_argument("-o", "--outdir", default="results", help="Output directory")
     parser.add_argument(
-      
+
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
         help="Set the logging level",
+    )
+    parser.add_argument(
+        "--caller",
+        choices=["deepvariant", "gatk"],
+        default="deepvariant",
+        help="Variant caller to use",
     )
     args = parser.parse_args()
 
@@ -133,13 +141,6 @@ def main() -> None:
         level=getattr(logging, args.log_level.upper()),
         format="%(levelname)s: %(message)s",
     )
-                                            
-        "--caller",
-        choices=["deepvariant", "gatk"],
-        default="deepvariant",
-        help="Variant caller to use",
-    )
-    args = parser.parse_args()
 
     for path, desc in [
         (args.bam, "BAM/CRAM file"),


### PR DESCRIPTION
## Summary
- Add `--caller` argument before initial parsing in `run_evaluation_pipeline`
- Remove redundant second `parse_args` call
- Allow `download_file` to accept filenames and print skip message when file exists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5b8494e3483339fd8e12e467fdbae