### PR TITLE
Replace print statements with logging in GIAB download script

### DIFF
--- a/scripts/download_hg002_giab.py
+++ b/scripts/download_hg002_giab.py
@@ -64,10 +64,10 @@ def download_file(file_info: dict, outdir: str) -> None:
     urlretrieve(url, dest)
     md5_sum, sha256_sum = _compute_checksums(dest)
     if md5_sum != expected_md5 or sha256_sum != expected_sha256:
-        print(f"[error] Checksum mismatch for {filename}; deleting file")
+        logging.error("[error] Checksum mismatch for %s; deleting file", filename)
         os.remove(dest)
     else:
-        print(f"[verified] {filename}")
+        logging.info("[verified] %s", filename)
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Download HG002 GIAB data")


### PR DESCRIPTION
## Summary
- log checksum errors and verification messages in `download_file`
- ensure all user-facing messaging in the downloader uses logging

## Testing
- `pytest -q` *(fails: command not found)*
- `python3 -m pip install pytest --break-system-packages` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b82f1b948333b2d8003a25d06592