### PR TITLE
Fix missing parenthesis in evaluation pipeline script

### DIFF
--- a/scripts/run_evaluation_pipeline.py
+++ b/scripts/run_evaluation_pipeline.py
@@ -44,7 +44,7 @@ def run(cmd: List[str]) -> None:
     if result.returncode != 0:
         if result.stderr:
             print(result.stderr)
-        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        raise subprocess.CalledProcessError(result.returncode, cmd, output=result.stdout, stderr=result.stderr)
 
 def run_deepvariant(bam: str, ref: str, out_dir: str) -> str:
     """Run DeepVariant and return the path to the output VCF."""


### PR DESCRIPTION
## Summary
- close a missing parenthesis in run_evaluation_pipeline.py's run function to properly raise CalledProcessError

## Testing
- `pytest -q` *(fails: IndentationError: unexpected indent in run_evaluation_pipeline.py line 137)*

------
https://chatgpt.com/codex/tasks/task_e_68a5b844db14833393df6dff87aeff8c