### PR TITLE
test: pass file info dict to download_file

### DIFF
--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -5,7 +5,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "scripts"))
 import download_hg002_giab as dl
 
 
-def test_download_file_skips_existing(tmp_path, monkeypatch, capsys):
+def test_download_file_skips_existing(tmp_path, monkeypatch, caplog):
     filename = "dummy.txt"
     dest = tmp_path / filename
     dest.write_text("existing")
@@ -15,6 +15,7 @@ def test_download_file_skips_existing(tmp_path, monkeypatch, capsys):
 
     monkeypatch.setattr(dl, "urlretrieve", fake_urlretrieve)
 
-    dl.download_file(filename, str(tmp_path))
-    captured = capsys.readouterr().out
-    assert "[skip]" in captured
+    file_info = {"name": filename, "md5": "", "sha256": ""}
+    with caplog.at_level("INFO"):
+        dl.download_file(file_info, str(tmp_path))
+    assert "[skip]" in caplog.text


### PR DESCRIPTION
## Summary
- update download test to pass file info dict instead of filename
- use caplog to assert skip message is logged

## Testing
- `pytest tests/test_download.py::test_download_file_skips_existing -q`
- `pytest -q` *(fails: SyntaxError in run_evaluation_pipeline.py)*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb8af3fc8333a9e7cfac24fb9ea8